### PR TITLE
Update types to match the DIF definitions

### DIFF
--- a/lib/issuance/manifest.ts
+++ b/lib/issuance/manifest.ts
@@ -100,21 +100,21 @@ export const generateIssuanceManifestForUser = (user: User): Manifest => {
       format: {
         jwt_vp: {
           alg: ["EdDSA", "ES256K"]
-        },
-        input_descriptors: [
-          {
-            id: "DID",
-            name: "DID",
-            purpose:
-              "The DID subject of the credential, and proof of current control over the DID.",
-            schema: [
-              {
-                uri: "https://www.w3.org/2018/credentials/v1"
-              }
-            ]
-          }
-        ]
-      }
+        }
+      },
+      input_descriptors: [
+        {
+          id: "DID",
+          name: "DID",
+          purpose:
+            "The DID subject of the credential, and proof of current control over the DID.",
+          schema: [
+            {
+              uri: "https://www.w3.org/2018/credentials/v1"
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/types/ClaimFormatDesignation.ts
+++ b/types/ClaimFormatDesignation.ts
@@ -1,0 +1,16 @@
+export type ClaimFormatDesignationAlg = {
+  alg: string[]
+}
+
+export type ClaimFormatDesignationProof = {
+  proof_type: string[]
+}
+
+export type ClaimFormatDesignation = {
+  jwt?: ClaimFormatDesignationAlg
+  jwt_vc?: ClaimFormatDesignationAlg
+  jwt_vp?: ClaimFormatDesignationAlg
+  ldp_vc?: ClaimFormatDesignationProof
+  ldp_vp?: ClaimFormatDesignationProof
+  ldp?: ClaimFormatDesignationProof
+}

--- a/types/DataDisplay.ts
+++ b/types/DataDisplay.ts
@@ -1,0 +1,50 @@
+// https://identity.foundation/credential-manifest/wallet-rendering/#data-display
+
+export type DataMappingSchemaNonString = {
+  type: "boolean" | "number" | "integer"
+}
+
+export type DataMappingSchemaString = {
+  type: "string"
+  format:
+    | "date-time"
+    | "time"
+    | "date"
+    | "email"
+    | "idn-email"
+    | "hostname"
+    | "idn-hostname"
+    | "ipv4"
+    | "ipv6"
+    | "uri"
+    | "uri-reference"
+    | "iri"
+    | "iri-reference"
+}
+
+export type DataMappingSchema =
+  | DataMappingSchemaString
+  | DataMappingSchemaNonString
+
+export type LabeledDataMappingSchema = DataMappingSchema & {
+  label: string
+}
+
+export type DataMappingText = {
+  text: string
+}
+
+export type DataMappingPath = {
+  path: string[]
+  fallback?: string
+  schema?: DataMappingSchema // NOTE: This is required, but left off in our case for our sample JSON
+}
+
+export type DisplayMapping = DataMappingPath | DataMappingText
+
+export type DataDisplay = {
+  title?: DisplayMapping
+  subtitle?: DisplayMapping
+  description?: DisplayMapping | { text: string }
+  properties?: LabeledDataMappingSchema[]
+}

--- a/types/EntityStyle.ts
+++ b/types/EntityStyle.ts
@@ -1,0 +1,17 @@
+// https://identity.foundation/credential-manifest/wallet-rendering/#entity-styles
+
+export type EntityStyleImage = {
+  uri: string
+  alt?: string
+}
+
+export type EntityStyleColor = {
+  color: string
+}
+
+export type EntityStyle = {
+  thumbnail?: EntityStyleImage
+  hero?: EntityStyleImage
+  background?: EntityStyleColor
+  text?: EntityStyleColor
+}

--- a/types/InputDescriptor.ts
+++ b/types/InputDescriptor.ts
@@ -1,0 +1,44 @@
+// https://identity.foundation/presentation-exchange/#input-descriptor-object
+
+import { Schema } from "./Schema"
+
+export type InputDescriptorConstraintStatus = {
+  directive: "required" | "allowed" | "disallowed"
+}
+
+export type InputDescriptorConstraintStatuses = {
+  active?: InputDescriptorConstraintStatus
+  suspended?: InputDescriptorConstraintStatus
+  revoked?: InputDescriptorConstraintStatus
+}
+
+export type InputDescriptorConstraintSubjectConstraint = {
+  field_id: string[]
+  directive: "required" | "preferred"
+}
+
+export type InputDescriptorConstraintField = {
+  path: string[]
+  id?: string
+  purpose?: string
+  filter?: Record<string, unknown>
+  predicate?: "required" | "preferred"
+}
+
+export type InputDescriptorConstraints = {
+  limit_disclosure?: "required" | "preferred"
+  statuses?: InputDescriptorConstraintStatuses
+  subject_is_issuer?: "required" | "preferred"
+  is_holder?: InputDescriptorConstraintSubjectConstraint[]
+  same_subject?: InputDescriptorConstraintSubjectConstraint[]
+  fields?: InputDescriptorConstraintField[]
+}
+
+export type InputDescriptor = {
+  id: string
+  schema: Schema[]
+  group?: string
+  name?: string
+  purpose?: string
+  constaints?: InputDescriptorConstraints
+}

--- a/types/Issuer.ts
+++ b/types/Issuer.ts
@@ -1,0 +1,8 @@
+import { EntityStyle } from "./EntityStyle"
+
+export type Issuer = {
+  id: string
+  name?: string
+  styles?: EntityStyle
+  comment?: string
+}

--- a/types/Manifest.ts
+++ b/types/Manifest.ts
@@ -1,80 +1,17 @@
-export type ManifestStyle = Record<string, unknown>
+// https://identity.foundation/credential-manifest/#general-composition
 
-export type StyleImage = {
-  uri: string
-  alt: string
-}
-
-export type StyleColor = {
-  color: string
-}
-
-export type ManifestIssuer = {
-  id: string
-  comment?: string
-  name: string
-  styles: ManifestStyle
-}
-
-export type ManifestFormatKind = {
-  alg: string[]
-}
-
-export type ManifestFormat = {
-  jwt_vc?: ManifestFormatKind
-  jwt_vp?: ManifestFormatKind
-}
-
-export type Schema = {
-  uri: string
-}
-
-export type OutputDescriptorDisplayPathWithFallback = {
-  path: string[]
-  fallback: string
-}
-
-export type OutputDescriptorDisplay = {
-  title: OutputDescriptorDisplayPathWithFallback | string
-  subtitle: OutputDescriptorDisplayPathWithFallback | string
-  description: { text: string }
-}
-
-export type OutputDescriptorStyle = {
-  thumbnail?: StyleImage
-  hero?: StyleImage
-  background?: StyleColor
-  text?: StyleColor
-}
-
-export type OutputDescriptor = {
-  id: string
-  schema: Schema[]
-  name: string
-  description: string
-  display: OutputDescriptorDisplay
-  styles?: OutputDescriptorStyle
-}
-
-export type InputDescriptor = {
-  id: string
-  name: string
-  purpose: string
-  schema: Schema[]
-}
-
-export type PresentationDefinition = {
-  id: string
-  format: ManifestFormat & { input_descriptors: InputDescriptor[] }
-}
+import { ClaimFormatDesignation } from "./ClaimFormatDesignation"
+import { Issuer } from "./Issuer"
+import { OutputDescriptor } from "./OutputDescriptor"
+import { PresentationDefinition } from "./PresentationDefinition"
 
 export type Manifest = {
   id: string
   version: string
-  issuer: ManifestIssuer
-  format: ManifestFormat
+  issuer: Issuer
   output_descriptors: OutputDescriptor[]
-  presentation_definition: PresentationDefinition
+  format?: ClaimFormatDesignation
+  presentation_definition?: PresentationDefinition
 }
 
 export type ManifestUrlObject = {

--- a/types/OutputDescriptor.ts
+++ b/types/OutputDescriptor.ts
@@ -1,0 +1,14 @@
+// https://identity.foundation/credential-manifest/#output-descriptor
+
+import { DataDisplay } from "./DataDisplay"
+import { EntityStyle } from "./EntityStyle"
+import { Schema } from "./Schema"
+
+export type OutputDescriptor = {
+  id: string
+  schema: Schema[]
+  name?: string
+  description?: string
+  styles?: EntityStyle | string
+  display?: DataDisplay
+}

--- a/types/PresentationDefinition.ts
+++ b/types/PresentationDefinition.ts
@@ -1,0 +1,11 @@
+import { ClaimFormatDesignation } from "./ClaimFormatDesignation"
+import { InputDescriptor } from "./InputDescriptor"
+
+// https://identity.foundation/presentation-exchange/#presentation-definition
+export type PresentationDefinition = {
+  id: string
+  input_descriptors: InputDescriptor[]
+  name?: string
+  purpose?: string
+  format?: ClaimFormatDesignation
+}

--- a/types/Schema.ts
+++ b/types/Schema.ts
@@ -1,0 +1,4 @@
+export type Schema = {
+  uri: string
+  required?: boolean
+}


### PR DESCRIPTION
This expands our types/Manifest.ts file to break out each part of the DIF specs for Credential Manifests.

NOTE: the sample JSON we supplied was mis-formatted.. it had previously included `input_descriptors` as a child of the presentation definition `format`.  This fixes our static code.