### PR TITLE
Add npm run dev to the top level project

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm run bootstrap
 
 ## Running the apps
 
+To run the `demo-site` while watching for changes in `vertity`, you can run
+
+```
+npm run dev
+```
+
 ### @centre/verity:
 
 ```

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "bootstrap": "npm install; lerna bootstrap",
     "build": "lerna run build --stream",
     "build:verity": "lerna run build --stream --scope @centre/verity",
-    "clean": "lerna run clean --stream",
-    "format": "lerna run format --stream",
-    "lint": "lerna run lint --stream",
+    "clean": "lerna run clean --parallel",
+    "dev": "lerna run dev --parallel",
+    "format": "lerna run format --parallel",
+    "lint": "lerna run lint --parallel",
     "metro": "lerna run start --stream --scope @centre/demo-wallet",
     "site": "lerna run dev --stream --scope @centre/demo-site",
-    "test": "lerna run test --stream",
+    "test": "lerna run test --parallel",
     "type-check": "lerna run type-check --stream"
   },
   "devDependencies": {

--- a/packages/verity/package.json
+++ b/packages/verity/package.json
@@ -6,8 +6,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "clean": "tsc --build --clean",
     "build": "tsc --build",
+    "clean": "tsc --build --clean",
+    "dev": "tsc --watch --preserveWatchOutput",
     "format": "prettier  --write .",
     "lint": "eslint .",
     "test": "jest",


### PR DESCRIPTION
This adds a `dev` npm script to run the `demo-site` and to set up a build watcher for `verity`