### PR TITLE
Add basic callback handling

### DIFF
--- a/packages/demo-site/lib/verification/callback.ts
+++ b/packages/demo-site/lib/verification/callback.ts
@@ -1,7 +1,0 @@
-import { NextApiHandler } from "next"
-
-const handler: NextApiHandler = (req, res) => {
-  res.json({ status: "ok" })
-}
-
-export default handler

--- a/packages/demo-site/lib/verification/responses.ts
+++ b/packages/demo-site/lib/verification/responses.ts
@@ -1,7 +1,0 @@
-import { NextApiHandler } from "next"
-
-const handler: NextApiHandler = (req, res) => {
-  res.json({ status: "ok" })
-}
-
-export default handler

--- a/packages/demo-site/pages/api/verification/callback.ts
+++ b/packages/demo-site/pages/api/verification/callback.ts
@@ -1,0 +1,9 @@
+import { apiHandler } from "lib/api-fns"
+
+type ResponseType = {
+  status: string
+}
+
+export default apiHandler<ResponseType>(async (req, res) => {
+  res.json({ status: "ok" })
+})

--- a/packages/demo-site/pages/api/verification/responses.ts
+++ b/packages/demo-site/pages/api/verification/responses.ts
@@ -2,7 +2,11 @@ import { EncodedVerificationSubmission } from "@centre/verity"
 import { apiHandler, methodNotAllowed, validationError } from "lib/api-fns"
 import { validateVerificationSubmission } from "lib/verification/submission"
 
-export default apiHandler(async (req, res) => {
+type ResponseType = {
+  status: string
+}
+
+export default apiHandler<ResponseType>(async (req, res) => {
   if (req.method !== "POST") {
     return methodNotAllowed(res)
   }


### PR DESCRIPTION
Was already there in `lib/verification/callback`, likely a mistake in where it was placed.