### PR TITLE
Update URLs to use NGROK_HOST env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ Local environment setup is handled by running the following script:
 npm run setup
 ```
 
-If using the demo mobile identity wallet, the server will automatically configure itself to use your local IP address. However, you can optionally create a tunnel through ngrok instead. Note, you must use `https` as it is required by iOS.
-
-```
-ngrok http 3000
-NGROK_HOST=https://f15f3dcbc823.ngrok.io npm run setup
-```
-
 This script will do the following:
 
 - Install all dependencies
@@ -49,6 +42,15 @@ Or, if you want to run everything together, simply run:
 
 ```sh
 npm run dev:all
+```
+
+## Running the Apps with ngrok
+
+If using the demo mobile identity wallet, the server will automatically configure itself to use your local IP address. However, you can optionally create a tunnel through ngrok instead. Note, you must use `https` as it is required by iOS.
+
+```
+ngrok http 3000
+NGROK_HOST=https://f15f3dcbc823.ngrok.io npm run dev
 ```
 
 ### Manually running services:

--- a/packages/demo-site/bin/local-ip.ts
+++ b/packages/demo-site/bin/local-ip.ts
@@ -1,9 +1,3 @@
 import internalIP from "internal-ip"
 
 console.log(`HOSTNAME=${internalIP.v4.sync()}`)
-
-if (process.env.NGROK_HOST) {
-  console.log(`NGROK_HOST=${process.env.NGROK_HOST}`)
-} else {
-  console.log(`NGROK_HOST=http://${internalIP.v4.sync()}:3000`)
-}

--- a/packages/demo-site/lib/api-fns.ts
+++ b/packages/demo-site/lib/api-fns.ts
@@ -107,3 +107,25 @@ function errorStatusCode(error: AnyError): number {
 
   return 500
 }
+
+/**
+ * Helper function to create a URL with the NGROK_HOST if given, otherwise the
+ * default HOST. Implementation uses the NEXT_PUBLIC_ prefix so they are
+ * available in both the server and client environments.
+ *
+ * Used for debugging purposes, this function is intended to be used for URLs
+ * used in Verifiable Credentials, Revocation URLs, QR Codes, etc to aid in
+ * routing traffic to a host. This allows us to tunnel traffic from a mobile
+ * identity wallet to the service runnong on localhost using ngrok.
+ *
+ * @param path of the route
+ * @returns A url with the NGROK_HOST as host if given, otherwise uses the
+ * default HOST env variable.
+ */
+export function publicUrl(path: string): string {
+  if (process.env.NEXT_PUBLIC_NGROK_HOST) {
+    return `${process.env.NEXT_PUBLIC_NGROK_HOST}${path}`
+  }
+
+  return `${process.env.NEXT_PUBLIC_HOST}${path}`
+}

--- a/packages/demo-site/lib/manifest/creditScore.ts
+++ b/packages/demo-site/lib/manifest/creditScore.ts
@@ -1,15 +1,16 @@
 import { createCreditScoreManifest } from "@centre/verity"
 import type { CredentialManifest } from "@centre/verity"
+import { publicUrl } from "../api-fns"
 import { manifestIssuer } from "./issuer"
 
 export const creditScoreManifest: CredentialManifest =
   createCreditScoreManifest(manifestIssuer, {
     thumbnail: {
-      uri: `${process.env.NEXT_PUBLIC_NGROK_HOST}/img/credit-score-thumbnail.png`,
+      uri: publicUrl(`/img/credit-score-thumbnail.png`),
       alt: "Verity Logo"
     },
     hero: {
-      uri: `${process.env.NEXT_PUBLIC_NGROK_HOST}/img/credit-score-hero.png`,
+      uri: publicUrl(`/img/credit-score-hero.png`),
       alt: "Credit Score Visual"
     },
     background: {

--- a/packages/demo-site/lib/manifest/kyc.ts
+++ b/packages/demo-site/lib/manifest/kyc.ts
@@ -1,16 +1,17 @@
 import { createKycAmlManifest } from "@centre/verity"
 import type { CredentialManifest } from "@centre/verity"
+import { publicUrl } from "../api-fns"
 import { manifestIssuer } from "./issuer"
 
 export const kycManifest: CredentialManifest = createKycAmlManifest(
   manifestIssuer,
   {
     thumbnail: {
-      uri: `${process.env.NEXT_PUBLIC_NGROK_HOST}/img/kyc-aml-thumbnail.png`,
+      uri: publicUrl(`/img/kyc-aml-thumbnail.png`),
       alt: "Verity Logo"
     },
     hero: {
-      uri: `${process.env.NEXT_PUBLIC_NGROK_HOST}/img/kyc-aml-hero.png`,
+      uri: publicUrl(`/img/kyc-aml-hero.png`),
       alt: "KYC+AML Visual"
     },
     background: {

--- a/packages/demo-site/package.json
+++ b/packages/demo-site/package.json
@@ -11,7 +11,6 @@
     "db:seed": "dotenv -c development prisma db seed -- --preview-feature",
     "db:studio": "dotenv -c development prisma studio",
     "dev": "next dev",
-    "ngrok": "ngrok http 3000",
     "format": "prettier  --write .",
     "lint": "next lint",
     "setup": "./bin/setup",

--- a/packages/demo-site/pages/api/manifests/[type]/[token].ts
+++ b/packages/demo-site/pages/api/manifests/[type]/[token].ts
@@ -1,7 +1,7 @@
 import type { ManifestWrapper } from "@centre/verity"
 import { manifestWrapper } from "@centre/verity"
 import { NotFoundError } from "../../../..//lib/errors"
-import { apiHandler } from "../../../../lib/api-fns"
+import { apiHandler, publicUrl } from "../../../../lib/api-fns"
 import { MANIFEST_MAP } from "../../../../lib/manifest"
 
 export default apiHandler<ManifestWrapper>(async (req, res) => {
@@ -13,7 +13,5 @@ export default apiHandler<ManifestWrapper>(async (req, res) => {
     throw new NotFoundError()
   }
 
-  res.json(
-    manifestWrapper(manifest, `${process.env.NGROK_HOST}/api/issuance/${token}`)
-  )
+  res.json(manifestWrapper(manifest, publicUrl(`/api/issuance/${token}`)))
 })

--- a/packages/demo-site/pages/api/revocation/[[...id]].ts
+++ b/packages/demo-site/pages/api/revocation/[[...id]].ts
@@ -1,10 +1,10 @@
 import type { RevocationListCredential } from "@centre/verity"
-import { apiHandler } from "../../../lib/api-fns"
+import { apiHandler, publicUrl } from "../../../lib/api-fns"
 import { getRevocationListById } from "../../../lib/database"
 import { NotFoundError } from "../../../lib/errors"
 
 export default apiHandler<RevocationListCredential>(async (req, res) => {
-  const q = `${process.env.NGROK_HOST}${req.url}`
+  const q = publicUrl(`${req.url}`) // TODO check this
   const revocationList = await getRevocationListById(q)
 
   if (!revocationList) {

--- a/packages/demo-site/pages/api/verification/index.ts
+++ b/packages/demo-site/pages/api/verification/index.ts
@@ -5,7 +5,7 @@ import {
   verificationRequestWrapper
 } from "@centre/verity"
 import { v4 as uuidv4 } from "uuid"
-import { apiHandler, requireMethod } from "../../../lib/api-fns"
+import { apiHandler, publicUrl, requireMethod } from "../../../lib/api-fns"
 import { saveVerificationRequest } from "../../../lib/database/verificationRequests"
 import { NotFoundError } from "../../../lib/errors"
 
@@ -48,7 +48,7 @@ export default apiHandler<PostResponse>(async (req, res) => {
     process.env.VERIFIER_DID,
     process.env.VERIFIER_DID,
     replyTo,
-    `${process.env.NEXT_PUBLIC_NGROK_HOST}/api/verification/${id}/callback`,
+    publicUrl(`/api/verification/${id}/callback`),
     [process.env.ISSUER_DID],
     { id, minimumCreditScore: 600 }
   )
@@ -59,7 +59,7 @@ export default apiHandler<PostResponse>(async (req, res) => {
     id,
     challenge: verificationRequestWrapper(verificationRequest),
     qrCodeData: challengeTokenUrlWrapper(
-      `${process.env.NEXT_PUBLIC_NGROK_HOST}/api/verification/${verificationRequest.request.id}`
+      publicUrl(`/api/verification/${verificationRequest.request.id}`)
     )
   })
 })
@@ -69,9 +69,7 @@ function replyUrl(
   subjectAddress?: string,
   contractAddress?: string
 ): string {
-  const url = new URL(
-    `${process.env.NEXT_PUBLIC_NGROK_HOST}/api/verification/${id}/submission`
-  )
+  const url = new URL(publicUrl(`/api/verification/${id}/submission`))
 
   if (subjectAddress) {
     url.searchParams.append("subjectAddress", subjectAddress)

--- a/packages/demo-site/pages/issuer/credit-score.tsx
+++ b/packages/demo-site/pages/issuer/credit-score.tsx
@@ -4,6 +4,7 @@ import { NextPage } from "next"
 import Link from "next/link"
 import QRCode from "qrcode.react"
 import IssuerLayout from "../../components/issuer/Layout"
+import { publicUrl } from "../../lib/api-fns"
 import { currentUser, requireAuth } from "../../lib/auth-fns"
 import { temporaryAuthToken } from "../../lib/database"
 import type { User } from "../../lib/database"
@@ -18,7 +19,7 @@ export const getServerSideProps = requireAuth<Props>(async (context) => {
   const user = await currentUser(context)
   const authToken = await temporaryAuthToken(user)
   const qrCodeData = challengeTokenUrlWrapper(
-    `${process.env.NGROK_HOST}/api/manifests/credit-score/${authToken}`
+    publicUrl(`/api/manifests/credit-score/${authToken}`)
   )
 
   const response = await fetch(qrCodeData.challengeTokenUrl)

--- a/packages/demo-site/pages/issuer/kyc.tsx
+++ b/packages/demo-site/pages/issuer/kyc.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import QRCode from "qrcode.react"
 import useSWR from "swr"
 import IssuerLayout from "../../components/issuer/Layout"
+import { publicUrl } from "../../lib/api-fns"
 import { currentUser, requireAuth } from "../../lib/auth-fns"
 import { temporaryAuthToken } from "../../lib/database"
 import type { User } from "../../lib/database"
@@ -22,7 +23,7 @@ export const getServerSideProps = requireAuth<Props>(async (context) => {
   const user = await currentUser(context)
   const authToken = await temporaryAuthToken(user)
   const qrCodeData = challengeTokenUrlWrapper(
-    `${process.env.NGROK_HOST}/api/manifests/kyc/${authToken}`
+    publicUrl(`/api/manifests/kyc/${authToken}`)
   )
 
   const response = await fetch(qrCodeData.challengeTokenUrl)

--- a/packages/demo-site/pages/verifier/[type].tsx
+++ b/packages/demo-site/pages/verifier/[type].tsx
@@ -1,3 +1,4 @@
+import { publicUrl } from "@centre/demo-site/lib/api-fns"
 import type { ChallengeTokenUrlWrapper } from "@centre/verity"
 import { Web3Provider } from "@ethersproject/providers"
 import { BadgeCheckIcon, XCircleIcon } from "@heroicons/react/outline"
@@ -230,7 +231,7 @@ const VerifierPage: NextPage = () => {
   const [verification, setVerification] = useState(null)
   const [title, setTitle] = useState("")
   const { type } = query
-  const baseUrl = `${process.env.NEXT_PUBLIC_NGROK_HOST}/api/verification?type=${type}`
+  const baseUrl = publicUrl(`/api/verification?type=${type}`)
 
   useEffect(() => {
     if (type === "kyc") {

--- a/packages/demo-site/prisma/seed.ts
+++ b/packages/demo-site/prisma/seed.ts
@@ -1,6 +1,7 @@
 import { asyncMap, buildIssuer, generateRevocationList } from "@centre/verity"
 import { PrismaClient, User } from "@prisma/client"
 import { v4 as uuidv4 } from "uuid"
+import { publicUrl } from "../lib/api-fns"
 import { saveRevocationList } from "../lib/database"
 
 const prisma = new PrismaClient()
@@ -41,7 +42,7 @@ async function main() {
 }
 
 async function createRevocationList() {
-  const url = `${process.env.NEXT_PUBLIC_NGROK_HOST}/api/revocation/${uuidv4()}`
+  const url = publicUrl(`/api/revocation/${uuidv4()}`)
   const issuer = process.env.ISSUER_DID
   const list = await generateRevocationList(
     [],


### PR DESCRIPTION
The idea was to allow `localhost` on the desktop, but then update the URLs in our manifests, revocation lists, callbacks, etc to go through NGROK_HOST. Basically the most minimal network requests.