### PR TITLE
Show RPC Error when MetaMask cannot connect to network

### DIFF
--- a/packages/demo-site/components/dapp/Dapp.tsx
+++ b/packages/demo-site/components/dapp/Dapp.tsx
@@ -327,11 +327,15 @@ const Dapp: FC = () => {
     data: { message: any }
     message: any
   }) => {
-    if (error.data?.message) {
+    if (error?.data?.message) {
       return error.data.message
     }
 
-    return error.message
+    if (error?.message) {
+      return error?.message
+    }
+
+    return "Unknown Error"
   }
 
   // If the token data or the user's balance hasn't loaded yet, we show


### PR DESCRIPTION
Seems that error messages can appear in two places. In this scenario, there was a data object, but it had no message. The message was at the root... So guard checks for not only data, but that there is a message on it.

<img width="793" alt="Screen Shot 2021-08-16 at 9 55 18 AM" src="https://user-images.githubusercontent.com/136454/129575210-5bf4dc1d-a3bb-44b1-b8fd-3b1b507b39b5.png">
