### PR TITLE
Fix verification status polling leak

### DIFF
--- a/packages/demo-site/components/dapp/Dapp.tsx
+++ b/packages/demo-site/components/dapp/Dapp.tsx
@@ -198,6 +198,10 @@ const Dapp: FC = () => {
   // End demo-site verifier
 
   const getVerificationResult = async () => {
+    // Clear verification if one exists. This will stop polling on the
+    // unsimulated verification workflow
+    setVerification(undefined)
+
     // in this recipe, the dApp calls a verifier by API and passes its
     // own subject address to be used in the verification result digest.
     // The verifier does not require proof of ownership of that address,

--- a/packages/demo-site/components/dapp/TransferStatus.tsx
+++ b/packages/demo-site/components/dapp/TransferStatus.tsx
@@ -39,7 +39,10 @@ const TransferStatus: FC<TransferStatusProps> = ({
       </label>
       <button
         type="submit"
-        onClick={simulateFunction}
+        onClick={(e) => {
+          e.preventDefault()
+          return simulateFunction()
+        }}
         className="inline-flex items-center px-4 py-2 text-sm font-medium text-blue-700 bg-blue-100 border border-transparent rounded-md hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
       >
         Simulate Verification


### PR DESCRIPTION
* Clear the Verification when simulating
* Prevent default when clicking the button because it was bubbling up to
  an onSubmit handler, which would trigger another transfer method,
  which would result in the same "Verifiable Credential: Transfers of
  this amount require validateAndTransfer" error, which would kick off
  the verification flow again.