### PR TITLE
Show contract errors unless it is the one signalling to start verifcation

### DIFF
--- a/packages/demo-site/components/dapp/Dapp.tsx
+++ b/packages/demo-site/components/dapp/Dapp.tsx
@@ -292,24 +292,29 @@ const Dapp: FC = () => {
         return
       }
 
+      const message = getRpcErrorMessage(error)
+
       // if the error is verification-related, we prompt -- this would be better handled
       // up front before the transfer, but for the sake of example, we show that
       // the contract is not relying solely on the web frontend to fire the error
-      if (
-        (error.message &&
-          error.message.indexOf("Verifiable Credential") !== -1) ||
-        (error.data?.message &&
-          error.data?.message?.indexOf("Verifiable Credential") !== -1)
-      ) {
+      if (message.indexOf("Verifiable Credential:") !== -1) {
         setIsVerifying(true)
+        setVerification(undefined)
+        setVerificationInfoSet(undefined)
+
         // Generate a QR code for scanning
         createVerification()
-        return
       }
 
-      // Other errors are logged and stored in the Dapp's state. This is used to
-      // show them to the user, and for debugging.
-      setTransactionError(getRpcErrorMessage(error))
+      // This is the error message to kick off the Verification workflow. We
+      // special case it so it is not shown to the user.
+      const sentinel =
+        "Verifiable Credential: Transfers of this amount require validateAndTransfer"
+      if (message.indexOf(sentinel) === -1) {
+        // Other errors are logged and stored in the Dapp's state. This is used to
+        // show them to the user, and for debugging.
+        setTransactionError(getRpcErrorMessage(error))
+      }
     } finally {
       // If we leave the try/catch, we aren't sending a tx anymore, so we clear
       // this part of the state.


### PR DESCRIPTION
The message `Verifiable Credential: Transfers of this amount require
validateAndTransfer" is only shown when a signer tries to call
`transfer` over the threshold. Therefore, we will skip showing an error
in that scenario as we handle it. Otherwise, we want to continue showing
errors for other contract errors beginning with the string "Verifiable
Credential" such as error messages when the verification is expired,
etc.

Example VC error and then it recreates a Verification Request for you
<img width="779" alt="Screen Shot 2021-08-19 at 3 54 28 PM" src="https://user-images.githubusercontent.com/136454/130136240-a7b1ab93-c540-4d33-9dee-fc13e60dca20.png">

Example of a non-VC error and no Verification Request being regenerated
<img width="791" alt="Screen Shot 2021-08-19 at 3 56 10 PM" src="https://user-images.githubusercontent.com/136454/130136246-bf889247-2a36-46e7-bc4e-b18c68bc6c28.png">
