### PR TITLE
Don't enforce expiry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27878,7 +27878,7 @@
         "qrcode.react": "^1.0.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-spinners": "*",
+        "react-spinners": "^0.11.0",
         "rimraf": "^3.0.2",
         "swr": "^0.5.6",
         "tailwindcss": "^2.2.4",

--- a/packages/demo-site/pages/api/issuance/[token].ts
+++ b/packages/demo-site/pages/api/issuance/[token].ts
@@ -61,19 +61,12 @@ export default apiHandler<EncodedCredentialFulfillment>(async (req, res) => {
   // a revocable credential for KYC/AML credentials.
   const revocationList = await handleRevocationIfNecessary(user, manifest)
 
-  // If this is a Credit Score attestation, set the expiration to be
-  // one minute for the sake of a demo
-  const expirationDate =
-    manifest.id === "CreditScoreAttestation"
-      ? new Date(Date.now() + oneMinute)
-      : undefined
-
   // Generate new credentials for the user
   const fulfillment = await buildAndSignFulfillment(
     buildIssuer(process.env.ISSUER_DID, process.env.ISSUER_SECRET),
     credentialApplication,
     buildAttestationForUser(user, manifest),
-    { credentialStatus: revocationList, expirationDate }
+    { credentialStatus: revocationList }
   )
 
   // Save the credentials to the database


### PR DESCRIPTION
We have a bug where we decodeVerifiableCredential also verifies it (part of did-jwt-vc) and will throw if the credential is expired.  Temporarily remove the expiration setting so we can build out more robust handling.