### PR TITLE
Add explit type for handleScan json parsing

### DIFF
--- a/packages/verity/lib/waci.ts
+++ b/packages/verity/lib/waci.ts
@@ -59,7 +59,7 @@ export function verificationRequestWrapper(
 export async function handleScan(
   scanData: string
 ): Promise<ManifestWrapper | VerificationRequestWrapper | undefined> {
-  const payload = json(scanData)
+  const payload = json(scanData) as ChallengeTokenUrlWrapper
 
   if (!payload.challengeTokenUrl) {
     return


### PR DESCRIPTION
Allows us to be a bit more explicit -- this came up when porting to demo-wallet.