### PR TITLE
remove incorrect json-ld types

### DIFF
--- a/packages/demo-site/test/fixtures/json/verification/kycAmlPresentationRequest.json
+++ b/packages/demo-site/test/fixtures/json/verification/kycAmlPresentationRequest.json
@@ -1,9 +1,4 @@
 {
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://identity.foundation/presentation-exchange/definition/v1"
-  ],
-  "type": ["VerifiablePresentation", "PresentationDefinition"],
   "request": {
     "id": "e2556c17-b781-4490-8b0c-d31c42571c9d",
     "from": "did:key:z6MktN192jgkc3RduEtC9QjWWbjdyVxTc3JHA7ouXrs6Vh6n",

--- a/packages/verity/lib/verification-request-fns.ts
+++ b/packages/verity/lib/verification-request-fns.ts
@@ -24,11 +24,6 @@ export function generateVerificationRequest(
   )
 
   return {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://identity.foundation/presentation-exchange/definition/v1"
-    ],
-    type: ["VerifiablePresentation", "PresentationDefinition"],
     request: {
       id: id as string,
       from: from,

--- a/packages/verity/types/VerificationRequest.ts
+++ b/packages/verity/types/VerificationRequest.ts
@@ -1,8 +1,6 @@
 import type { PresentationDefinition } from "./PresentationDefinition"
 
 export type VerificationRequest = {
-  "@context": string[]
-  type: string[]
   request: {
     id: string
     from: string


### PR DESCRIPTION
The type was incorrect on the presentation request -- it's not a VP. Rather than fix that, it's best to remove all JSON-LD, since we don't need that here (and this isn't part of any standard we need to adhere to).

This is part 6 of VER 144