### PR TITLE
Allow setting a domain for cookies

### DIFF
--- a/packages/demos/pages/api/auth/site.ts
+++ b/packages/demos/pages/api/auth/site.ts
@@ -21,6 +21,7 @@ export default apiHandler<Response>(async (req, res) => {
 
   if (isAuthenticated) {
     cookies.set("verity-auth", "1", {
+      domain: process.env.COOKIE_DOMAIN,
       httpOnly: false
     })
     res.status(200).json({ status: "ok" })


### PR DESCRIPTION
Will allow us to set cookies on `.verity.id` to work across subdomains