### PR TITLE
add schema and issuer setup instructions

### DIFF
--- a/packages/docs/docs/patterns/schema.md
+++ b/packages/docs/docs/patterns/schema.md
@@ -1,0 +1,65 @@
+---
+sidebar_label: Sceham Design
+sidebar_position: 8
+---
+
+# Recommendations for Credential Schema Design
+
+## Intro
+
+Decentralized identity specifications are being actively developed by a broad range of communities and stakeholders who are committed to the vision of user-controlled, privacy-preserving identity management. There is a solid pipeline of standards-track specifications enabling building out of the decentralized identity ecosystem, with the foundational specifications reaching standard status.[^1]
+
+While the primary specification influencing credential schemas is the VC data model, other specifications, such as those covering signature suites, as well as issuance and exchange protocols, can also impact the security, privacy, and usability of credentials for the user.
+
+## Cross-Cutting Considerations
+
+### Consider ability for relying parties to consume the credentials
+
+While some ecosystems may seamlessly support ZKPs signature suites, this cannot always be assumed -- especially given the relatively limited library availability (and possible concerns around maturity of related specifications). For that reason, it is helpful to give subjects the option to receive credentials that are signed via schemes with broad, interoperable support like JWT signatures.
+
+Credential issuance protocols allow subjects and issuers to reach agreement on which signature scheme to use, so this guidance doesn’t imply a “downgrade” to the minimal option.
+
+Issuers of ZKP credentials may include a higher amount of sensitive attributes in a single credential (because it expects the wallet to handle reducing disclosure), but a non-ZKP credential should minimize attributes, per the [VC Data Model privacy recommendations](https://www.w3.org/TR/did-core/#privacy-considerations). ZKPs impose tooling requirements on wallets to manage, which may be feasible in a closed system where one vendor supplies all the pieces, but difficult otherwise.
+
+### Ensure credential status registries, such as revocation lists, do not leak additional information
+
+The VC Data Model’s guidance on credential status registries can be difficult to reconcile: it mentions that revocation should not reveal additional information (about the subject, holder, the VC, or verifier) but also states that the issuers can disclose revocation reason, and that they should distinguish between revocation for cryptographic integrity vs a revocation status change.
+
+In practice, it tends to be clearest for implementers (and safest for users) to use simple inclusion approaches to revocation or status registries, such as (TODO: LINK TO BITSTRING DOC), which only reveals whether a credential index is in the set of revoked credentials, with no additional information about reason. Contents of status registries require special scrutiny, particularly since they may be on-chain. Because it can be hard to predict how any additional information can be discovered, correlated, and potentially misused, it is best to avoid providing any additional signals.
+
+### Allow reissuance and new DIDs
+
+Similar to how some use different crypto addresses to avoid correlation, some users may prefer to use different DIDs for different credentials. In fact, use of a new DID for every credential is generally considered best practice. This doesn’t manifest as a usability issue for subjects because their wallet software can manage this for them, both on the issuance and exchange (if proof of control is required) side.
+
+In case the subject needs the credential to be issued to a different DID (key compromise or other concern), it’s recommended to use the refreshService property to allow a subject’s wallet to easily discover a way to request a new one. The issuer should revoke the previous and re-issue in response.
+
+## Recommendations
+
+The following are recommendations for safe practices while making minimal assumptions.
+
+### Reduce attributes required of the credential subject through fit-for-purpose
+
+The Verifiable Credentials Data Model provides general guidance on the [principle of data minimization](https://www.w3.org/TR/vc-data-model/#the-principle-of-data-minimization), involving reducing the amount of personal information revealed to verifiers, either through issuance of multiple single-attribute credentials or through data minimizing signature suites such as ZKPs. Lack of library availability, or concerns about maturity, may discourage some implementers from relying on the latter. At the same time, it can be difficult for issuers to envision how to property atomize credentials into single-attribute credentials: not all attributes are meant to be mixed and matched in different combinations.
+
+A simpler approach is to tailor credential schemas to one specific use case, and avoiding use of one credential schema for multiple use cases. As an example, the Verity schema for a KYC/AML compliance credential is intended only to communicate KYC/AML compliance for a given country, while excluding adjacent use cases such as support for “jurisdiction shopping” (excluding residents of states with stricter regulatory requirements). This separation enabled a KYC/AML claim with minimal subject attributes -- not requiring detailed residence information about the subject.
+
+### Prefer composability of credentials
+
+Along with reducing the data required of a subject, careful consideration of the intended use of credentials help enable composable, stackable credentials that can be aggregated into presentations requested by relying parties. The combination of credential exchange protocols and wallet software enable this to happen without additional burden to the user.
+
+Composing and stacking credentials is another way to achieve some effects enabled by ZKPs, while not disclosing more information needed for a given scenario.
+
+Continuing the jurisdiction shopping example described above, suppose a verifier wanted to restrict to users that have been KYCs, and additionally, do not live in a specific state. With the composable approach, the subject would be issued a KYC credential and a separate residence credential, which would be combined to support the presentation requested by the verifier[^2].
+
+### Prefer reuse of existing schemas and vocabularies
+
+There are not yet standard repositories of VC schemas and vocabularies, but often it’s helpful to reuse any source of structured data appropriate to the domain. Schema.org is often a good starting place for the broadest expression of types and relations, and many domain-specific vocabularies are designed to fit within schema.org.
+
+Re-use of schema.org terms is highly recommended, even if it’s unclear whether it’s _meant_ to apply to the use case. This is more apparent in practice than in documentation, but the usual practice is to re-use terms that already exist rather than coin new ones, even where this means slight changes to definition, extending the domain and range or properties.
+
+<!-- Footnotes themselves at the bottom. -->
+
+## Notes
+
+[^1]: [W3C Verifiable Credential Data Model](https://www.w3.org/TR/vc-data-model/) is endorsed as a W3C recommendation, and the [W3C Decentralized Identifier Data Model](https://www.w3.org/TR/did-core/) is a proposed W3C recommendation.
+[^2]: But note that ZKPs could offer further improvements on the credential contents, more easily expressing “not a resident of” certain locations

--- a/packages/docs/docs/tutorials/issue-a-verifiable-credential.md
+++ b/packages/docs/docs/tutorials/issue-a-verifiable-credential.md
@@ -9,6 +9,10 @@ _This tutorial will walk you through issuing verifiable credentials using the ve
 
 For the sake of this demo, we will be using Decentralized Identifiers (DIDs) to identify the issuer (you) and subject (the person or entity the credential is about), as well as JSON Web Tokens (JWTs) as the means of signing and verifying the credentials. In practice, you are not limited to using DIDs to prove ownership; anything with a public/private key pair is a valid owner. Likewise, you do not need to use JWTs.
 
+## Prerequisites: Issuer Setup
+
+[See issuer setup instructions](/docs/tutorials/issuer-setup).
+
 ## Step 1: Create a DID for your issuer
 
 In order to issue a credential, you must have some way of identifying yourself as an Issuer. This allows the credential to be "verifiable" by a 3rd party.
@@ -16,9 +20,9 @@ In order to issue a credential, you must have some way of identifying yourself a
 To start, you should create a DID keypair.
 
 ```ts
-import { randomDidKey } from "@centre/verity";
+import { randomDidKey } from "@centre/verity"
 
-const issuerDidKey = randomDidKey();
+const issuerDidKey = randomDidKey()
 ```
 
 That keypair should look like the following:
@@ -53,9 +57,9 @@ Generally, you would follow the [Presentation Exchange (PEx)](https://identity.f
 To do so, you need to create a [Credential Manifest](https://identity.foundation/credential-manifest/) showcasing what attestations you offer as Verifiable Credentials. In this example, we will offer a "Know Your Customer, Anti-Money Laundering" attestation (KYC/AML Attestation), meaning we are compliant with US regulations and have checked your account to determined you are not a bad actor. The benefit of this type of VC is that another service can be compliant with regulations without any personal information exposed in the VC.
 
 ```ts
-import { buildKycAmlManifest } from "@centre/verity";
+import { buildKycAmlManifest } from "@centre/verity"
 
-const manifest = buildKycAmlManifest({ id: issuerDidKey.controller });
+const manifest = buildKycAmlManifest({ id: issuerDidKey.controller })
 ```
 
 This manifest contains instructions for the subject to use to request a VC.
@@ -63,12 +67,12 @@ This manifest contains instructions for the subject to use to request a VC.
 The subject uses that manifest to build a “Credential Application”, which serves as a request for a VC. For example, a subject could create the application as such:
 
 ```ts
-import { randomDidKey, buildCredentialApplication } from "@centre/verity";
+import { randomDidKey, buildCredentialApplication } from "@centre/verity"
 
 // The subject needs a did:key, generate a random one:
-const subjectDidKey = randomDidKey();
+const subjectDidKey = randomDidKey()
 
-const application = await buildCredentialApplication(subject, manifest);
+const application = await buildCredentialApplication(subject, manifest)
 ```
 
 ## Step 3: Issue the Verifiable Credential
@@ -86,26 +90,26 @@ import {
   buildAndSignFulfillment,
   decodeCredentialApplication,
   buildIssuer,
-  KYCAMLAttestation,
-} from "@centre/verity";
+  KYCAMLAttestation
+} from "@centre/verity"
 
-const decodedApplication = await decodeCredentialApplication(application);
+const decodedApplication = await decodeCredentialApplication(application)
 
 const attestation: KYCAMLAttestation = {
   "@type": "KYCAMLAttestation",
   authorityId: "did:web:verity.id",
   approvalDate: new Date().toISOString(),
   authorityName: "verity.id",
-  authorityUrl: "https://verity.id",
-};
+  authorityUrl: "https://verity.id"
+}
 
-const issuer = buildIssuer(issuerDidKey.subject, issuerDidKey.privateKey);
+const issuer = buildIssuer(issuerDidKey.subject, issuerDidKey.privateKey)
 
 const presentation = await buildAndSignFulfillment(
   issuer,
   decodedApplication,
   attestation
-);
+)
 ```
 
 The subject can then decode the presentation and store their Verifiable Credential for future use.

--- a/packages/docs/docs/tutorials/issuer-setup.md
+++ b/packages/docs/docs/tutorials/issuer-setup.md
@@ -1,18 +1,20 @@
 ---
+sidebar_label: Issuer Setup
 sidebar_position: 4
 ---
 
 # Issuer Setup
 
-This will describe various setup steps an issuer must do before issuing, including
+Before issuing credentials, you will need to following at minimum.
 
-1. Deciding what types of credentials to issue, including schemas
-   - In the Verity reference, we've included a few representative schemas, such as proof of KYC and credit score.
-   - Include information about supplying your own?
-2. How to expose #1 info to credential recipients (and wallets)
-   - Credential Manifests:
-     - Verity's reference implementation uses DIF Credential Manifests to allow an issuer to describe what sort of credentials they issue
-     - Issuer defines a credential manifest, which includes the prerequisites and output schemas
-   - Issuer supplies a way for recipients to discover the credential manifest, such as adding a QR code or deep link into a mobile app on their web site: Verity encodes as a QR code in the demo-site
-3. Decide what type of DID method to use (TODO: link to identifier best practices)
-4. etc
+1. Deciding what types of credentials to issue, and their schemas
+   - Verity includes a few representative schemas, such as proof of KYC and chain address ownership.
+   - See [Recommendations for Credential Schema Design](/docs/patterns/schema).
+2. Decide what type of issuing identifier method (e.g., DID method) you want to use.
+   - In order for verifiers to verify credentials, they must be able to determine your authorized signing keys.
+   - If you are using a DID method, you will need to ensure you are signing credentials with keys resolvable from the DID.
+   - See [Identifier Methods](/docs/patterns/identifier) for factors in this decision.
+3. Allow users and credential wallets to discover how to interact with you as an issuer
+   - In the flows described here, this starts with a QR code or deep link that the user opens from their credential wallet
+   - The flow should enable the wallet to discover metadata about how to request and receive the credential
+   - Verity uses [DIF Credential Manifest](https://identity.foundation/credential-manifest/) for this purpose. It allowa an issuer to describe what sort of credentials they issue, prerequisites for issuance, and output schemas


### PR DESCRIPTION
Add schema design recommendations and hopefully address [this](https://linear.app/verity/issue/VER-209/credential-issuance-tutorial-is-missing-the-credential-offer-step).

This is an incredibly minimal effort attempt at the issuer setup, but I wanted to get something out. Will improve it later