### PR TITLE
Update docs to have issuer use did:web for the example paylods

### DIFF
--- a/packages/docs/docs/appendix/messages.md
+++ b/packages/docs/docs/appendix/messages.md
@@ -13,9 +13,9 @@ sidebar_position: 2
   "credentialSubject": {
     "KYCAMLAttestation": {
       "@type": "KYCAMLAttestation",
-      "process": "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
+      "process": "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
       "approvalDate": "2021-09-14T02:00:07.540Z",
-      "authorityId": "did:web:demos.verity.id",
+      "authorityId": "did:web:verity.id",
       "authorityName": "Verity",
       "authorityUrl": "https://verity.id",
       "authorityCallbackUrl": "https://identity.verity.id"
@@ -23,7 +23,7 @@ sidebar_position: 2
     "id": "did:key:z6Mkjo9pGYpv88SCYZW3ZT1dxrKYJrPf6u6hBeGexChJF4EN"
   },
   "issuer": {
-    "id": "did:key:z6Mkgw8mPijYRa3TkHSYtQ4P7S2HGrcJBwzdgjeurqr9Luqb"
+    "id": "did:web:verity.id"
   },
   "type": ["VerifiableCredential", "KYCAMLAttestation"],
   "@context": [
@@ -45,9 +45,9 @@ sidebar_position: 2
   "credentialSubject": {
     "KYCAMLAttestation": {
       "@type": "KYCAMLAttestation",
-      "process": "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
+      "process": "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
       "approvalDate": "2021-09-14T02:00:07.540Z",
-      "authorityId": "did:web:demos.verity.id",
+      "authorityId": "did:web:verity.id",
       "authorityName": "Verity",
       "authorityUrl": "https://verity.id",
       "authorityCallbackUrl": "https://identity.verity.id"
@@ -55,7 +55,7 @@ sidebar_position: 2
     "id": "did:key:z6Mkjo9pGYpv88SCYZW3ZT1dxrKYJrPf6u6hBeGexChJF4EN"
   },
   "issuer": {
-    "id": "did:key:z6Mkgw8mPijYRa3TkHSYtQ4P7S2HGrcJBwzdgjeurqr9Luqb"
+    "id": "did:web:verity.id"
   },
   "type": ["VerifiableCredential", "KYCAMLAttestation"],
   "credentialStatus": {
@@ -130,7 +130,7 @@ Example DIF Credential Manifest for a KYCAMLAttestation issued by a fictional is
       "id": "kycAttestationOutput",
       "schema": [
         {
-          "uri": "https://demos.verity.id/schemas/identity/1.0.0/KYCAMLAttestation"
+          "uri": "https://verity.id/schemas/identity/1.0.0/KYCAMLAttestation"
         }
       ],
       "name": "Proof of KYC from Verity",
@@ -212,7 +212,7 @@ Example DIF Credential Manifest for a KYCAMLAttestation issued by a fictional is
         "purpose": "A Verifiable Presentation establishing proof of identifier control over the DID.",
         "schema": [
           {
-            "uri": "https://demos.verity.id/schemas/identity/1.0.0/ProofOfControl"
+            "uri": "https://verity.id/schemas/identity/1.0.0/ProofOfControl"
           }
         ]
       }
@@ -336,8 +336,8 @@ Details:
         "id": "did:key:z6Mkjo9pGYpv88SCYZW3ZT1dxrKYJrPf6u6hBeGexChJF4EN",
         "KYCAMLAttestation": {
           "@type": "KYCAMLAttestation",
-          "process": "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
-          "authorityId": "did:web:demos.verity.id",
+          "process": "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
+          "authorityId": "did:web:verity.id",
           "approvalDate": "2021-09-14T02:00:07.540Z",
           "authorityName": "Verity",
           "authorityUrl": "https://verity.id",
@@ -345,7 +345,7 @@ Details:
         }
       },
       "issuer": {
-        "id": "did:key:z6Mkgw8mPijYRa3TkHSYtQ4P7S2HGrcJBwzdgjeurqr9Luqb"
+        "id": "did:web:verity.id"
       }
     }
   ]

--- a/packages/docs/docs/appendix/schemas.mdx
+++ b/packages/docs/docs/appendix/schemas.mdx
@@ -19,7 +19,7 @@ The KYC/AML attestation structure is intended to address regulatory compliance o
 ```json
 {
   "@type": "KYCAMLAttestation",
-  "process": "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
+  "process": "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
   "approvalDate": "2021-08-25T02:13:43.387Z",
   "authorityId": "did:web:trapezoid.id",
   "authorityName": "Trapezoid LLC",
@@ -66,7 +66,7 @@ The "authorityCallbackUrl" attribute is used to define the url at which VCs can 
 - Additional details obtained during the KYC/AML process should not be included in the attestation. For example, service provider scores are not needed and will leak personal information.
 - Support for additional use cases (such as jurisdiction shopping) that require additional data should be accomplished in ways that enable the subject to provide the least amount of data required. This may be accomplised with ZKPs or by issuing separate credentials containing the additional attributes (such as residence), enabling wallet aggregation of minimal required data.
 
-Verity's intial release contains only the USA KYC/AML process definition ("https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",). Additional process defnitions will be developed based on existing practices/requirements per country.
+Verity's intial release contains only the USA KYC/AML process definition ("https://verity.id/schemas/definitions/1.0.0/kycaml/usa",). Additional process defnitions will be developed based on existing practices/requirements per country.
 
 ## Address Ownership
 

--- a/packages/docs/docs/tutorials/issue-a-verifiable-credential.md
+++ b/packages/docs/docs/tutorials/issue-a-verifiable-credential.md
@@ -79,7 +79,7 @@ const application = await buildCredentialApplication(subject, manifest)
 
 Once the subject has requested a VC and submitted their DID (as part of their credential application), the Issuer can create a VC.
 
-For our example, we're building a VC containing a KYC/AML Attestation. This attestation is quite simple in Verity. It defines an authority which has performed proper KYC/AML checks on the subject (in this example the authority is Verity, with the DID of `did:web:demos.verity.id`).
+For our example, we're building a VC containing a KYC/AML Attestation. This attestation is quite simple in Verity. It defines an authority which has performed proper KYC/AML checks on the subject (in this example the authority is Verity, with the DID of `did:web:verity.id`).
 
 We transport Verifiable Credentials using a Verifiable Presentation. The presentation is just a way of transferring credentials, with the benefit that the presentation creator does not need to be the credential issuer or subject.
 
@@ -97,8 +97,8 @@ const decodedApplication = await decodeCredentialApplication(application)
 
 const attestation: KYCAMLAttestation = {
   "@type": "KYCAMLAttestation",
-  process: "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
-  authorityId: "did:web:demos.verity.id",
+  process: "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
+  authorityId: "did:web:verity.id",
   approvalDate: new Date().toISOString(),
   authorityName: "verity.id",
   authorityUrl: "https://verity.id"

--- a/packages/docs/docs/tutorials/revoke-a-credential.md
+++ b/packages/docs/docs/tutorials/revoke-a-credential.md
@@ -98,7 +98,7 @@ const subject = randomDidKey()
 // Stubbed out credential data
 const attestation: KYCAMLAttestation = {
   "@type": "KYCAMLAttestation",
-  process: "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
+  process: "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
   authorityId: "verity.id",
   approvalDate: new Date().toISOString(),
   authorityName: "verity.id",

--- a/packages/docs/docs/tutorials/wallet-guide.md
+++ b/packages/docs/docs/tutorials/wallet-guide.md
@@ -66,7 +66,7 @@ This flow is based on the [DIF wallet and credential interaction (draft) specifi
 1. Recipient initiates the credential request process by scanning QR code with their mobile wallet
 2. The wallet decodes the QR code, which provides an issuer endpoint with more details to continue the interaction:
 
-   1. QR code returns the URL from which to receive information at the` challengeTokenUrl`:
+   1. QR code returns the URL from which to receive information at the `challengeTokenUrl`:
 
       ```json
       {
@@ -258,9 +258,9 @@ A credential application is sent from the wallet to the issuer before issuance. 
   "credentialSubject": {
     "KYCAMLAttestation": {
       "@type": "KYCAMLAttestation",
-      "process": "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
+      "process": "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
       "approvalDate": "2021-09-14T02:00:07.540Z",
-      "authorityId": "did:web:demos.verity.id",
+      "authorityId": "did:web:verity.id",
       "authorityName": "Verity",
       "authorityUrl": "https://verity.id",
       "authorityCallbackUrl": "https://identity.verity.id"
@@ -268,7 +268,7 @@ A credential application is sent from the wallet to the issuer before issuance. 
     "id": "did:key:z6Mkjo9pGYpv88SCYZW3ZT1dxrKYJrPf6u6hBeGexChJF4EN"
   },
   "issuer": {
-    "id": "did:key:z6Mkgw8mPijYRa3TkHSYtQ4P7S2HGrcJBwzdgjeurqr9Luqb"
+    "id": "did:web:verity.id"
   },
   "credentialStatus": {
     "id": "http://192.168.1.16:3000/api/revocation/05c74310-4810-4ec4-8402-cee4c28dda91#94372",
@@ -350,8 +350,8 @@ Details:
         "id": "did:key:z6Mkjo9pGYpv88SCYZW3ZT1dxrKYJrPf6u6hBeGexChJF4EN",
         "KYCAMLAttestation": {
           "@type": "KYCAMLAttestation",
-          "process": "https://demos.verity.id/schemas/definitions/1.0.0/kycaml/usa",
-          "authorityId": "did:web:demos.verity.id",
+          "process": "https://verity.id/schemas/definitions/1.0.0/kycaml/usa",
+          "authorityId": "did:web:verity.id",
           "approvalDate": "2021-09-14T02:00:07.540Z",
           "authorityName": "Verity",
           "authorityUrl": "https://verity.id",
@@ -359,7 +359,7 @@ Details:
         }
       },
       "issuer": {
-        "id": "did:key:z6Mkgw8mPijYRa3TkHSYtQ4P7S2HGrcJBwzdgjeurqr9Luqb"
+        "id": "did:web:verity.id"
       }
     }
   ]


### PR DESCRIPTION
I found some of the docs to be confusing when seeing a `did:key` as the issuer, especially if the did:key was similar to the subject did:key.  This updates to use `did:web:verity.id` as the issuer in all the documentation examples.

It also updates the docs to move from `demos.verity.id` to `verity.id` in all other places, as they don't need to map to the actual demos did:web record.