### PR TITLE
fixed setup to write .env.local demo url properly

### DIFF
--- a/packages/demos/next-env.d.ts
+++ b/packages/demos/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/packages/docs/bin/local-ip.ts
+++ b/packages/docs/bin/local-ip.ts
@@ -1,3 +1,3 @@
 import internalIP from "internal-ip"
 
-console.log(`DEMOS_URL=${internalIP.v4.sync()}:3000`)
+console.log(`DEMOS_URL=http://${internalIP.v4.sync()}:3000`)


### PR DESCRIPTION
When running `npm run setup` to run the site and docs locally, the `.env.local` file is created in the `docs` folder. This is done with the `bin/local-ip.ts` file. This was writing the demo URL without the protocol handler (no http://). This mean that when on the documentation page, if you clicked the Demos link in the header, the page would not be found.

This only effect running the site and demos locally, but figured it was still worth fixing. 