### PR TITLE
Return encoded revocation list credentials from the API

### DIFF
--- a/packages/demo-revocation/pages/index.tsx
+++ b/packages/demo-revocation/pages/index.tsx
@@ -37,12 +37,12 @@ const issueRevocationList = async () => {
    * Note that the second parameter should be a URL that resolves to the
    * Revocation List Credential.
    */
-  return generateRevocationList(
-    [],
-    "http://localhost:3000/api/demos/revocation",
-    issuer.did,
-    issuer
-  )
+  return generateRevocationList({
+    statusList: [],
+    url: "http://localhost:3000/api/demos/revocation",
+    issuer: issuer.did,
+    signer: issuer
+  })
 }
 
 /**

--- a/packages/e2e-demo/pages/api/demos/revocation/[id].ts
+++ b/packages/e2e-demo/pages/api/demos/revocation/[id].ts
@@ -1,9 +1,9 @@
-import type { RevocationListCredential } from "verite"
+import type { EncodedRevocationListCredential } from "verite"
 import { apiHandler } from "../../../../lib/api-fns"
 import { getRevocationListById } from "../../../../lib/database"
 import { NotFoundError } from "../../../../lib/errors"
 
-export default apiHandler<RevocationListCredential>(async (req, res) => {
+export default apiHandler<EncodedRevocationListCredential>(async (req, res) => {
   const id = req.query.id as string
 
   const revocationList = await getRevocationListById(id)

--- a/packages/verite/types/RevocationList2021.ts
+++ b/packages/verite/types/RevocationList2021.ts
@@ -1,4 +1,5 @@
 import type { Verifiable, W3CCredential, W3CPresentation } from "./DidJwt"
+import { JWT } from "./Jwt"
 
 export type RevocationList2021Status = {
   id: string
@@ -33,3 +34,4 @@ export type RevocationList<T> = T & {
 }
 
 export type RevocationListCredential = RevocationList<Verifiable<W3CCredential>>
+export type EncodedRevocationListCredential = JWT


### PR DESCRIPTION
We had been returning this as a decoded credential, while it should be encoded.