### PR TITLE
Update header Demos link to link to github

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -27,7 +27,7 @@ module.exports = {
           position: "left"
         },
         {
-          to: process.env.DEMOS_URL || "/",
+          to: "https://github.com/centrehq/verite/tree/main/packages/e2e-demo#readme",
           label: "Demos",
           position: "left",
           target: "_self"


### PR DESCRIPTION
Previous PR (#306) was too far reaching and broke the temporary docs auth.