### PR TITLE
Update HH task to use given network

### DIFF
--- a/packages/contract/hardhat.config.ts
+++ b/packages/contract/hardhat.config.ts
@@ -243,7 +243,7 @@ task(
     const domain = {
       name: "VerificationRegistry",
       version: "1.0",
-      chainId: 1337,
+      chainId: hre.network.config.chainId ?? 1337,
       verifyingContract: registry.address
     }
 


### PR DESCRIPTION
Use the given network supplied by the `--network` argument. Otherwise,
fallback to 1337.