### PR TITLE
Decrease hero title size on mobile

### DIFF
--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -76,4 +76,8 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
   .hero.hero--primary.heroBanner_src-pages-index-module {
     padding: 2rem 0.5rem;
   }
+
+  .hero__title {
+    font-size: 2.5rem;
+  }
 }


### PR DESCRIPTION
old:

<img width="327" alt="Screen Shot 2022-02-17 at 7 56 47 AM" src="https://user-images.githubusercontent.com/540442/154486241-bb53eb2f-7ae4-4ba0-a69f-846db3058840.png">

new:
<img width="320" alt="Screen Shot 2022-02-17 at 7 57 02 AM" src="https://user-images.githubusercontent.com/540442/154486289-08cfb1f9-f72d-4080-835d-6e03fa1fa558.png">

