### PR TITLE
fix breaking change from did-jwt

### DIFF
--- a/packages/verite/package.json
+++ b/packages/verite/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "ajv": "^8.6.3",
     "bit-buffers": "^1.0.2",
-    "did-jwt-vc": "^2.1.6",
+    "did-jwt": "^6.1.2",
+    "did-jwt-vc": "^2.1.12",
     "did-resolver": "^3.1.0",
     "ethers": "^5.4.4",
     "isomorphic-unfetch": "^3.1.0",


### PR DESCRIPTION
`parseKey` used to be called in `EdDSASigner`, but it was removed. This is from the `did-jwt` library, which we use directly and use via `did-jwt-vc`. 

Confirmed tests are passing. I need to do a few more small changes and then I'll push a package update