### PR TITLE
Use a more generic 'Attestation' type for building fulfillments

### DIFF
--- a/packages/demo-issuer/pages/api/credentials/[token].ts
+++ b/packages/demo-issuer/pages/api/credentials/[token].ts
@@ -3,8 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next"
 import {
   buildAndSignFulfillment,
   decodeCredentialApplication,
-  KYCAMLAttestation,
-  CreditScoreAttestation,
+  Attestation,
   buildIssuer
 } from "verite"
 
@@ -44,16 +43,16 @@ export default async function credentials(
    * Generate the attestation.
    */
   const manifestId = application.credential_application.manifest_id
-  let attestation: KYCAMLAttestation | CreditScoreAttestation
+  let attestation: Attestation
   if (manifestId === "KYCAMLAttestation") {
     attestation = {
-      "type": "KYCAMLAttestation",
+      type: "KYCAMLAttestation",
       process: "https://demos.verite.id/schemas/definitions/1.0.0/kycaml/usa",
       approvalDate: new Date().toISOString()
     }
   } else if (manifestId === "CreditScoreAttestation") {
     attestation = {
-      "type": "CreditScoreAttestation",
+      type: "CreditScoreAttestation",
       score: 90,
       scoreType: "Credit Score",
       provider: "Experian"

--- a/packages/e2e-demo/lib/issuance/fulfillment.ts
+++ b/packages/e2e-demo/lib/issuance/fulfillment.ts
@@ -1,28 +1,28 @@
 import {
   CREDIT_SCORE_ATTESTATION_MANIFEST_ID,
   KYCAML_ATTESTATION_MANIFEST_ID,
-  CredentialManifest
+  CredentialManifest,
+  Attestation
 } from "verite"
 
 import type { User } from "../database"
-import type { CreditScoreAttestation, KYCAMLAttestation } from "verite"
 
 export function buildAttestationForUser(
   user: User,
   manifest: CredentialManifest
-): KYCAMLAttestation | CreditScoreAttestation {
+): Attestation {
   if (manifest.id === KYCAML_ATTESTATION_MANIFEST_ID) {
     return {
       type: "KYCAMLAttestation",
       process: "https://demos.verite.id/schemas/definitions/1.0.0/kycaml/usa",
       approvalDate: new Date().toJSON()
-    } as KYCAMLAttestation
+    }
   } else if (manifest.id === CREDIT_SCORE_ATTESTATION_MANIFEST_ID) {
     return {
       type: "CreditScoreAttestation",
       score: user.creditScore,
       scoreType: "Credit Score",
       provider: "Experian"
-    } as CreditScoreAttestation
+    }
   }
 }

--- a/packages/verite/lib/issuer/credential-fulfillment.ts
+++ b/packages/verite/lib/issuer/credential-fulfillment.ts
@@ -10,12 +10,11 @@ import type {
   DescriptorMap,
   EncodedCredentialFulfillment,
   Issuer,
-  KYCAMLAttestation,
   DecodedCredentialApplication,
-  CreditScoreAttestation,
   CredentialPayload,
   DidKey,
-  JWT
+  JWT,
+  Attestation
 } from "../../types"
 import type {
   CreateCredentialOptions,
@@ -28,7 +27,7 @@ import type {
 export async function buildAndSignVerifiableCredential(
   signer: Issuer,
   subject: string | DidKey,
-  attestation: KYCAMLAttestation | CreditScoreAttestation,
+  attestation: Attestation,
   payload: Partial<CredentialPayload> = {},
   options?: CreateCredentialOptions
 ): Promise<JWT> {
@@ -61,7 +60,7 @@ export async function buildAndSignVerifiableCredential(
 export async function buildAndSignFulfillment(
   signer: Issuer,
   application: DecodedCredentialApplication,
-  attestation: KYCAMLAttestation | CreditScoreAttestation,
+  attestation: Attestation,
   payload: Partial<CredentialPayload> = {},
   options?: CreatePresentationOptions
 ): Promise<EncodedCredentialFulfillment> {

--- a/packages/verite/lib/validators/validate-schema.ts
+++ b/packages/verite/lib/validators/validate-schema.ts
@@ -1,13 +1,14 @@
 import Ajv from "ajv"
 
-import { CreditScoreAttestation, KYCAMLAttestation } from "../../types"
 import { ValidationError } from "../errors"
+
+import type { Attestation } from "../../types"
 export { findSchemaById } from "./schemas"
 
 const ajv = new Ajv()
 
 export function validateAttestationSchema(
-  attestation: KYCAMLAttestation | CreditScoreAttestation,
+  attestation: Attestation,
   schema: Record<string, unknown>
 ): void {
   if (!attestation) {

--- a/packages/verite/types/Attestations.ts
+++ b/packages/verite/types/Attestations.ts
@@ -1,7 +1,23 @@
-import type { Person } from "schema-dts"
+import type { PostalAddress } from "schema-dts"
+
+/**
+ * This is a union type for the possible types of attestations.
+ */
+export type Attestation =
+  | KYCAMLAttestation
+  | KYBPAMLAttestation
+  | CreditScoreAttestation
+  | AddressOwner
+  | CounterpartyAccountHolder
 
 export type KYCAMLAttestation = {
   type: "KYCAMLAttestation"
+  process: string
+  approvalDate: string
+}
+
+export type KYBPAMLAttestation = {
+  type: "KYBPAMLAttestation"
   process: string
   approvalDate: string
 }
@@ -20,7 +36,11 @@ export type AddressOwner = {
   proof: string
 }
 
-export type CounterpartyAccountHolder = Person & {
+export type CounterpartyAccountHolder = {
+  type: "CounterpartyAccountHolder"
+  legalName: string
+  address: Omit<PostalAddress, "@type"> & { type: "PostalAddress" }
   accountNumber: string
-  accountSource: string
+  accountSource?: string
+  legalID?: string
 }


### PR DESCRIPTION
This PR updates the built-in Attestation types to match those defined on the [Schemas](https://verite.id/verite/appendix/schemas) document.  Likewise, it loosens some constraints on `buildAndSignVerifiableCredential` and `buildAndSignFulfillment` to allow for these other Attestations to be used (previously it would only allow KYCAML/Credit Score)