### PR TITLE
Fetch external schemas if not a built-in type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50081,7 +50081,7 @@
         "eslint-import-resolver-typescript": "^2.4.0",
         "eslint-plugin-import": "^2.23.4",
         "jest": "^28.1.1",
-        "nock": "^13.1.3",
+        "nock": "^13.2.7",
         "prettier": "^2.3.2",
         "rimraf": "^3.0.2",
         "ts-jest": "^28.0.5",

--- a/packages/verite/lib/validators/schemas/index.ts
+++ b/packages/verite/lib/validators/schemas/index.ts
@@ -1,14 +1,34 @@
+import fetch from "cross-fetch"
+
 import * as creditScoreSchema from "./CreditScoreAttestation.json"
 import * as kycSchema from "./KYCAMLAttestation.json"
 
-export const SCHEMA_MAP: Record<string, Record<string, unknown>> = {
+const schemaCache: Record<string, Record<string, unknown>> = {
   "https://demos.verite.id/schemas/identity/1.0.0/KYCAMLAttestation": kycSchema,
   "https://demos.verite.id/schemas/identity/1.0.0/CreditScoreAttestation":
     creditScoreSchema
 }
 
-export function findSchemaById(
+async function fetchSchemaFromUrl(
+  url: string
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    const res = await fetch(url)
+
+    if (res.ok) {
+      const json = await res.json()
+      schemaCache[url] = json
+      return json
+    }
+  } catch (e) {}
+}
+
+export async function findSchemaById(
   id: string
-): Record<string, unknown> | undefined {
-  return SCHEMA_MAP[id]
+): Promise<Record<string, unknown> | undefined> {
+  if (schemaCache[id]) {
+    return schemaCache[id]
+  }
+
+  return fetchSchemaFromUrl(id)
 }

--- a/packages/verite/package.json
+++ b/packages/verite/package.json
@@ -56,7 +56,7 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.23.4",
     "jest": "^28.1.1",
-    "nock": "^13.1.3",
+    "nock": "^13.2.7",
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^28.0.5",


### PR DESCRIPTION
If one of our hard-coded schemas is not being used, fetch it to be used in validation. Fail otherwise.