### PR TITLE
chore: use setup node action cache

### DIFF
--- a/packages/wallet/.github/workflows/ci.yml
+++ b/packages/wallet/.github/workflows/ci.yml
@@ -11,15 +11,11 @@ jobs:
     name: "Lint & Test"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: "16"
+          cache: "npm"
       - run: npm install
       - run: npm run type-check
       - run: npm run lint


### PR DESCRIPTION
## Problem
This repo is using deprecated cache action versions:
https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/

## Solution
Use the setup node action caching which has npm caching built in.

## Testing
The PR builder is working as expected.